### PR TITLE
Code tag accepts an attribute to override code highlighting language (when not happy with the "heuristics").

### DIFF
--- a/BBCode/BBCode.php
+++ b/BBCode/BBCode.php
@@ -93,7 +93,14 @@ class BBCodePlugin extends MantisFormattingPlugin {
 		$p_string = preg_replace( '/\[center\](.+)\[\/center\]/imsU', "<center>\$1</center>", $p_string );
 		$p_string = preg_replace( '/\[hr\]/iU', "<hr />", $p_string );
 		$p_string = preg_replace( '/\[color=(.+)\](.+)\[\/color\]/imsU', "<span style=\"color:\$1;\">\$2</span>", $p_string );
-		$p_string = preg_replace( '/\[code\](.+)\[\/code\]/imsU', "<pre><code>\$1</code></pre>", $p_string );
+		$p_string = preg_replace( 
+			array( 
+				'/\[code=(\w+)\](.+)\[\/code\]/imsU', 
+				'/\[code\](.+)\[\/code\]/imsU'),
+			array(
+				"<pre><code class=\"\$1\">\$2</code></pre>",
+				"<pre><code>\$1</code></pre>"),
+			$p_string);
 		
 		if ( $t_change_quotes )
 			ini_set( 'magic_quotes_sybase', TRUE );

--- a/BBCode/README.txt
+++ b/BBCode/README.txt
@@ -37,3 +37,4 @@ Supported bbcode:
 	[hr]          => <hr>
 	[color=#333]  => <span style="color: #333;">
 	[code]        => <pre><code>
+	[code=php]    => <pre><code class="php">


### PR DESCRIPTION
Language override is any of the supported Highlight.js languages.
E.g. [code=php] will highlight PHP code, [code=java] - Java code.
This will override the heuristics mechanism used by Highlight.js.
